### PR TITLE
Feature: Initialize K8s cluster on Hetzner

### DIFF
--- a/infrastructure/hetzner/ansible.cfg
+++ b/infrastructure/hetzner/ansible.cfg
@@ -1,0 +1,12 @@
+[defaults]
+inventory = inventory.yml
+remote_user = root
+host_key_checking = False
+callbacks_enabled = profile_tasks
+stdout_callback = yaml
+roles_path = roles
+private_key_file = ../keys/hetzner-k8s
+
+[ssh_connection]
+pipelining = True
+control_path = /tmp/ansible-ssh-%%h-%%p-%%r

--- a/infrastructure/hetzner/bootstrap.yml
+++ b/infrastructure/hetzner/bootstrap.yml
@@ -1,0 +1,224 @@
+---
+# Ansible bootstrap.yml
+- hosts: all
+  become: yes
+  vars:
+    kubernetes_version: "1.29"
+    pod_network_cidr: "10.244.0.0/16"
+
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Upgrade system packages
+      apt:
+        upgrade: yes
+
+    - name: Install dependencies
+      apt:
+        name: 
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg
+          - lsb-release
+        state: present
+
+    - name: Add Helm GPG key
+      shell: curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
+      args:
+        creates: /usr/share/keyrings/helm.gpg
+
+    - name: Add Helm repository
+      apt_repository:
+        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main"
+        state: present
+        filename: helm-stable-debian
+        update_cache: yes  # Add this line to update cache after adding repo
+
+    - name: Install Helm
+      apt:
+        name: helm
+        state: present
+
+    - name: Add Docker GPG key
+      apt_key:
+        url: https://download.docker.com/linux/debian/gpg
+        state: present
+
+    - name: Add Docker repository
+      apt_repository:
+        repo: "deb [arch=amd64] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable"
+        state: present
+
+    - name: Install containerd
+      apt:
+        name: containerd.io
+        state: present
+
+    - name: Create containerd config directory
+      file:
+        path: /etc/containerd
+        state: directory
+
+    - name: Configure containerd
+      shell: |
+        containerd config default | tee /etc/containerd/config.toml
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+      notify: Restart containerd
+
+    - name: Configure containerd
+      shell: |
+        containerd config default > /etc/containerd/config.toml
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+        sed -i 's/disabled_plugins = \[\"cri\"\]/enabled_plugins = \[\"cri\"\]/' /etc/containerd/config.toml
+      notify: Restart containerd
+
+    - name: Enable and restart containerd
+      systemd:
+        name: containerd
+        state: restarted
+        enabled: yes
+        daemon_reload: yes
+      
+    # Add a small delay to ensure containerd is fully ready
+    - name: Wait for containerd to be ready
+      wait_for:
+        path: /run/containerd/containerd.sock
+        state: present
+        delay: 5
+        timeout: 30
+
+    - name: Add Kubernetes GPG key
+      apt_key:
+        url: https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/Release.key
+        state: present
+
+    - name: Add Kubernetes repository
+      apt_repository:
+        repo: "deb https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/ /"
+        state: present
+
+    - name: Install Kubernetes packages
+      apt:
+        name:
+          - kubelet
+          - kubeadm
+          - kubectl
+        state: present
+
+    - name: Hold Kubernetes packages
+      dpkg_selections:
+        name: "{{ item }}"
+        selection: hold
+      loop:
+        - kubelet
+        - kubeadm
+        - kubectl
+
+    - name: Disable swap
+      command: swapoff -a
+      changed_when: false
+
+    - name: Remove swap from fstab
+      replace:
+        path: /etc/fstab
+        regexp: '^([^#].*?\sswap\s+sw\s+.*)$'
+        replace: '# \1'
+
+    - name: Configure kernel modules
+      copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+
+    - name: Load kernel modules
+      modprobe:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - overlay
+        - br_netfilter
+
+    - name: Configure sysctl parameters
+      sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        state: present
+        reload: yes
+      loop:
+        - { name: 'net.bridge.bridge-nf-call-iptables', value: '1' }
+        - { name: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }
+        - { name: 'net.ipv4.ip_forward', value: '1' }
+        - { name: 'vm.swappiness', value: '0' }
+        - { name: 'net.ipv4.conf.all.forwarding', value: '1' }
+        # Add these for better k8s networking performance
+        - { name: 'net.core.somaxconn', value: '32768' }
+        - { name: 'net.ipv4.tcp_max_syn_backlog', value: '8096' }
+        - { name: 'net.ipv4.tcp_tw_reuse', value: '1' }
+
+    - name: Initialize Kubernetes cluster
+      command: >
+        kubeadm init
+        --pod-network-cidr={{ pod_network_cidr }}
+        --skip-phases=addon/kube-proxy
+      register: kubeadm_init
+      changed_when: kubeadm_init.rc == 0
+      failed_when: 
+        - kubeadm_init.rc != 0
+        - "'already exists' not in kubeadm_init.stderr"
+
+    - name: Create .kube directory
+      file:
+        path: /root/.kube
+        state: directory
+        mode: '0755'
+
+    - name: Copy admin.conf to root's .kube directory
+      copy:
+        src: /etc/kubernetes/admin.conf
+        dest: /root/.kube/config
+        remote_src: yes
+        mode: '0600'
+
+    - name: Install Cilium
+      block:
+        - name: Add Cilium helm repository
+          kubernetes.core.helm_repository:
+            name: cilium
+            repo_url: https://helm.cilium.io/
+
+        - name: Install Cilium
+          kubernetes.core.helm:
+            name: cilium
+            chart_ref: cilium/cilium
+            release_namespace: kube-system
+            values:
+              kubeProxyReplacement: true  # Changed from 'strict' to true
+              k8sServiceHost: "{{ ansible_host }}"  # Add host IP
+              k8sServicePort: 6443  # Add API port
+
+    - name: Install additional system utilities
+      apt:
+        name: 
+          - ipvsadm  # For better k8s service proxy
+          - jq       # For JSON processing
+          - nfs-common  # For storage support
+        state: present
+
+    - name: Remove control-plane taint
+      command: kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+      register: taint_result
+      changed_when: taint_result.rc == 0
+      failed_when:
+        - taint_result.rc != 0
+        - "'not found' not in taint_result.stderr"
+
+  handlers:
+    - name: Restart containerd
+      service:
+        name: containerd
+        state: restarted

--- a/infrastructure/hetzner/inventory.yml
+++ b/infrastructure/hetzner/inventory.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    k8s_master:
+      ansible_host: 188.245.235.142  # This will be replaced by the script
+      ansible_user: root

--- a/infrastructure/hetzner/inventory.yml.template
+++ b/infrastructure/hetzner/inventory.yml.template
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    k8s_master:
+      ansible_host: KUBERNETES_MASTER_IP  # This will be replaced by the script
+      ansible_user: root

--- a/infrastructure/hetzner/main.tf
+++ b/infrastructure/hetzner/main.tf
@@ -1,0 +1,49 @@
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+resource "hcloud_server" "k8s_node" {
+  name        = "k8s-master"
+  image       = "debian-12"
+  server_type = "cx22"
+  location    = "fsn1"
+  ssh_keys    = [hcloud_ssh_key.default.id]
+
+  labels = {
+    environment = "learning"
+    managed_by  = "terraform"
+  }
+
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = false # Disable IPv6 if not needed
+  }
+
+  # Wait for SSH to be available
+  provisioner "remote-exec" {
+    inline = ["echo 'SSH is ready'"]
+
+    connection {
+      host        = self.ipv4_address
+      type        = "ssh"
+      user        = "root"
+      private_key = file("${path.module}/../keys/hetzner-k8s")
+    }
+  }
+}
+
+resource "hcloud_ssh_key" "default" {
+  name       = "hetzner-k8s"
+  public_key = file("${path.module}/../keys/hetzner-k8s.pub")
+}
+
+output "k8s_node_ip" {
+  value       = hcloud_server.k8s_node.ipv4_address
+  description = "Public IP of the k8s node"
+}
+
+# Output SSH command for easy access
+output "ssh_command" {
+  value       = "ssh -i ${path.module}/../keys/hetzner-k8s root@${hcloud_server.k8s_node.ipv4_address}"
+  description = "SSH command to connect to the server"
+}

--- a/infrastructure/hetzner/variables.tf
+++ b/infrastructure/hetzner/variables.tf
@@ -1,0 +1,5 @@
+variable "hcloud_token" {
+  description = "Hetzner Cloud API Token"
+  type        = string
+  sensitive   = true # Marks as sensitive to hide in logs
+}

--- a/infrastructure/hetzner/version.tf
+++ b/infrastructure/hetzner/version.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.44.1"
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the initial Kubernetes cluster setup on Hetzner Cloud using Terraform and Ansible.

Key changes:
- Add Terraform configs for Hetzner infrastructure
- Implement Ansible playbook for K8s bootstrap
- Run basic test

Testing:
- [x] Terraform apply successful
- [x] Ansible all tasks passed
- [x] Kubectl basic access to cluster

Closes #1