### PR TITLE
fix: Add missing 'version_mapping' to kube-bench config

### DIFF
--- a/infrastructure/hetzner/k8s-resources.yml
+++ b/infrastructure/hetzner/k8s-resources.yml
@@ -107,6 +107,8 @@
 
   
   tasks:
+    # Always rebuilds all images, I've tried tracking file content, it's cumbersome
+    # Probably would need other method than ansible
     - name: Find all Dockerfiles
       find:
         paths: "{{ docker_images_path }}"
@@ -115,49 +117,49 @@
       delegate_to: localhost
       become: no
       register: dockerfiles
-
-    - name: Calculate Dockerfile checksums
-      stat:
-        path: "{{ item.path }}"
-      delegate_to: localhost
-      become: no
-      register: dockerfile_stats
-      loop: "{{ dockerfiles.files }}"
-
+    
     - name: Build Docker images
       docker_image:
         build:
-          path: "{{ item.stat.path | dirname }}"
+          path: "{{ item.path | dirname }}"
           pull: yes
-        name: "localhost:{{ registry_port }}/{{ item.stat.path | dirname | basename }}"
+        name: "localhost:{{ registry_port }}/{{ item.path | dirname | basename }}"
         tag: latest
         source: build
-        force_source: "{{ item.stat.checksum_mismatch | default(false) }}"
-      loop: "{{ dockerfile_stats.results }}"
+        force_source: yes
+      loop: "{{ dockerfiles.files }}"
       delegate_to: localhost
       become: no
-    
+        
     - name: Save Docker images
       shell: |
-        docker save -o "/tmp/{{ item.stat.path | dirname | basename }}.tar" \
-        localhost:5000/{{ item.stat.path | dirname | basename }}:latest
-      loop: "{{ dockerfile_stats.results }}"
+        docker save -o "/tmp/{{ item.path | dirname | basename }}.tar" \
+        localhost:5000/{{ item.path | dirname | basename }}:latest
+      loop: "{{ dockerfiles.files }}"
       delegate_to: localhost
       become: no
       changed_when: false
     
     - name: Copy image to remote host
       copy:
-        src: "/tmp/{{ item.stat.path | dirname | basename }}.tar"
-        dest: "/tmp/{{ item.stat.path | dirname | basename }}.tar"
-      loop: "{{ dockerfile_stats.results }}"
+        src: "/tmp/{{ item.path | dirname | basename }}.tar"
+        dest: "/tmp/{{ item.path | dirname | basename }}.tar"
+      loop: "{{ dockerfiles.files }}"
       delegate_to: k8s_master
       become: yes
     
+    - name: Remove existing image from containerd
+      shell: |
+        ctr -n=k8s.io image rm localhost:5000/{{ item.path | dirname | basename }}:latest || true
+      loop: "{{ dockerfiles.files }}"
+      delegate_to: k8s_master
+      become: yes
+      changed_when: false
+    
     - name: Import image to containerd
       shell: |
-        ctr -n=k8s.io images import "/tmp/{{ item.stat.path | dirname | basename }}.tar"
-      loop: "{{ dockerfile_stats.results }}"
+        ctr -n=k8s.io images import "/tmp/{{ item.path | dirname | basename }}.tar"
+      loop: "{{ dockerfiles.files }}"
       delegate_to: k8s_master
       become: yes
       changed_when: false

--- a/infrastructure/hetzner/k8s-resources.yml
+++ b/infrastructure/hetzner/k8s-resources.yml
@@ -1,0 +1,188 @@
+---
+# Handles containers and k8s manifests state at the dirs specified below
+- hosts: all
+  become: yes
+  vars_files:
+    - secret_vars.yml
+  vars:
+    docker_images_path: "../../kubernetes/dockerfiles"
+    k8s_manifests_path: "../../kubernetes/base/manifests"
+    registry_name: "local-registry"
+    registry_port: "5000"
+    ansible_become_pass: "{{ ansible_become_pass }}"
+  
+  pre_tasks:
+    # Check Kubernetes initialization
+    - name: Check if Kubernetes is initialized
+      stat:
+        path: /etc/kubernetes/admin.conf
+      register: k8s_check
+
+    - name: Fail if Kubernetes is not initialized
+      fail:
+        msg: "Kubernetes is not initialized. Please run bootstrap.yml first"
+      when: not k8s_check.stat.exists
+
+    # Check local Docker prerequisites
+    - name: Check if Docker is installed locally
+      command: docker --version
+      delegate_to: localhost
+      become: no
+      register: docker_check
+      ignore_errors: yes
+      changed_when: false
+
+    - name: Fail if Docker is not installed
+      fail:
+        msg: "Docker is not installed on localhost. Please install Docker first."
+      when: docker_check.rc != 0
+      delegate_to: localhost
+      become: no
+
+    - name: Check if Docker is running locally
+      command: docker info
+      delegate_to: localhost
+      become: no
+      register: docker_running
+      ignore_errors: yes
+      changed_when: false
+
+    - name: Fail if Docker is not running
+      fail:
+        msg: "Docker is not running on localhost. Please start Docker service."
+      when: docker_running.rc != 0
+      delegate_to: localhost
+      become: no
+
+    # Check and create local registry if needed
+    - name: Check if registry container exists
+      shell: docker ps -a --filter name={{ registry_name }} --format "{% raw %}{{.Names}}{% endraw %}"
+      delegate_to: localhost
+      become: no
+      register: registry_exists
+      changed_when: false
+
+    - name: Check if registry is running
+      shell: docker ps --filter name={{ registry_name }} --format "{% raw %}{{.Names}}{% endraw %}"
+      delegate_to: localhost
+      become: no
+      register: registry_running
+      changed_when: false
+
+    - name: Start registry if exists but not running
+      command: docker start {{ registry_name }}
+      delegate_to: localhost
+      become: no
+      when: 
+        - registry_exists.stdout == registry_name
+        - registry_running.stdout != registry_name
+
+    - name: Create registry if doesn't exist
+      command: docker run -d --restart always -p {{ registry_port }}:5000 --name {{ registry_name }} registry:2
+      delegate_to: localhost
+      become: no
+      when: registry_exists.stdout != registry_name
+
+    - name: Wait for registry to be ready
+      uri:
+        url: "http://localhost:{{ registry_port }}/v2/_catalog"
+        method: GET
+      register: registry_health
+      until: registry_health.status == 200
+      retries: 5
+      delay: 2
+      delegate_to: localhost
+      become: no
+
+    - name: Ensure required python packages are installed
+      apt:
+        name: 
+          - python3-pip
+          - python3-dev
+          - python3-kubernetes
+        state: present
+        update_cache: yes
+      delegate_to: localhost
+      become: yes
+
+  
+  tasks:
+    - name: Find all Dockerfiles
+      find:
+        paths: "{{ docker_images_path }}"
+        patterns: "Dockerfile"
+        recurse: yes
+      delegate_to: localhost
+      become: no
+      register: dockerfiles
+
+    - name: Calculate Dockerfile checksums
+      stat:
+        path: "{{ item.path }}"
+      delegate_to: localhost
+      become: no
+      register: dockerfile_stats
+      loop: "{{ dockerfiles.files }}"
+
+    - name: Build Docker images
+      docker_image:
+        build:
+          path: "{{ item.stat.path | dirname }}"
+          pull: yes
+        name: "localhost:{{ registry_port }}/{{ item.stat.path | dirname | basename }}"
+        tag: latest
+        source: build
+        force_source: "{{ item.stat.checksum_mismatch | default(false) }}"
+      loop: "{{ dockerfile_stats.results }}"
+      delegate_to: localhost
+      become: no
+    
+    - name: Save Docker images
+      shell: |
+        docker save -o "/tmp/{{ item.stat.path | dirname | basename }}.tar" \
+        localhost:5000/{{ item.stat.path | dirname | basename }}:latest
+      loop: "{{ dockerfile_stats.results }}"
+      delegate_to: localhost
+      become: no
+      changed_when: false
+    
+    - name: Copy image to remote host
+      copy:
+        src: "/tmp/{{ item.stat.path | dirname | basename }}.tar"
+        dest: "/tmp/{{ item.stat.path | dirname | basename }}.tar"
+      loop: "{{ dockerfile_stats.results }}"
+      delegate_to: k8s_master
+      become: yes
+    
+    - name: Import image to containerd
+      shell: |
+        ctr -n=k8s.io images import "/tmp/{{ item.stat.path | dirname | basename }}.tar"
+      loop: "{{ dockerfile_stats.results }}"
+      delegate_to: k8s_master
+      become: yes
+      changed_when: false
+
+    - name: Find all K8s manifests
+      find:
+        paths: "{{ k8s_manifests_path }}"
+        patterns: "*.yaml,*.yml"
+        recurse: no
+      delegate_to: localhost
+      become: no
+      register: k8s_files
+
+    - name: Apply K8s manifests
+      kubernetes.core.k8s:
+        state: present
+        src: "{{ item.path }}"
+      loop: "{{ k8s_files.files }}"
+      delegate_to: localhost  # Run this task on the local machine
+      become: no
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
+
+    - name: Create CIS reports directory
+      file:
+        path: /var/log/cis-linux-and-kube-bench
+        state: directory
+        mode: '0755'

--- a/kubernetes/base/manifests/linux-bench-and-kube-bench.yaml
+++ b/kubernetes/base/manifests/linux-bench-and-kube-bench.yaml
@@ -1,0 +1,101 @@
+---
+# ServiceAccount for CIS checks
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cis-checker
+  namespace: default
+---
+# ClusterRole with necessary permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cis-checker
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods", "namespaces"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets"]
+  verbs: ["get", "list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
+  verbs: ["get", "list"]
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["get", "list"]
+---
+# Bind the ClusterRole to the ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cis-checker
+subjects:
+- kind: ServiceAccount
+  name: cis-checker
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cis-checker
+  apiGroup: rbac.authorization.k8s.io
+---
+# CronJob for running checks
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cis-compliance-check
+  namespace: default
+spec:
+  schedule: "0 0 * * *"  # Run daily at midnight
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: cis-checker
+          containers:
+          - name: cis-checker
+            image: localhost:5000/cis-linux-and-kube-bench:latest
+            imagePullPolicy: Never 
+            securityContext:
+              privileged: true  # Required for system checks
+              runAsUser: 0      # Run as root
+              runAsGroup: 0
+            volumeMounts:
+            - name: reports
+              mountPath: /reports
+            - name: host-root
+              mountPath: /host
+              readOnly: true
+            - name: host-proc
+              mountPath: /proc
+              readOnly: true
+            - name: host-etc
+              mountPath: /etc
+              readOnly: true
+          volumes:
+          - name: reports
+            hostPath:
+              path: /var/log/cis-linux-and-kube-bench
+              type: DirectoryOrCreate
+          - name: host-root
+            hostPath:
+              path: /
+              type: Directory
+          - name: host-proc
+            hostPath:
+              path: /proc
+              type: Directory
+          - name: host-etc
+            hostPath:
+              path: /etc
+              type: Directory
+          restartPolicy: OnFailure
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
@@ -1,4 +1,3 @@
-# kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
 FROM debian:bookworm-slim
 
 # Install base dependencies
@@ -11,7 +10,12 @@ RUN apt-get update && \
 # Create reports directory
 RUN mkdir -p /reports
 
-# Download and install the benchmark tools
+# Create directory for linux-bench config
+RUN mkdir -p ./cfg/2.0.0
+
+# Download linux-bench definitions.yaml
+RUN wget -O ./cfg/2.0.0/definitions.yaml https://raw.githubusercontent.com/aquasecurity/linux-bench/main/cfg/2.0.0/definitions.yaml
+
 # Download and install the benchmark tools
 RUN wget https://github.com/aquasecurity/kube-bench/releases/download/v0.9.4/kube-bench_0.9.4_linux_amd64.deb && \
     wget https://github.com/aquasecurity/linux-bench/releases/download/v0.5.0/linux-bench_0.5.0_linux_amd64.deb && \

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
@@ -7,22 +7,10 @@ RUN apt-get update && \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Create reports directory
-RUN mkdir -p /reports
+COPY bootstrap.sh /tmp/bootstrap.sh
 
-# Create directory for linux-bench config
-RUN mkdir -p ./cfg/2.0.0
+RUN chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh
 
-# Download linux-bench definitions.yaml
-RUN wget -O ./cfg/2.0.0/definitions.yaml https://raw.githubusercontent.com/aquasecurity/linux-bench/main/cfg/2.0.0/definitions.yaml
-
-# Download and install the benchmark tools
-RUN wget https://github.com/aquasecurity/kube-bench/releases/download/v0.9.4/kube-bench_0.9.4_linux_amd64.deb && \
-    wget https://github.com/aquasecurity/linux-bench/releases/download/v0.5.0/linux-bench_0.5.0_linux_amd64.deb && \
-    apt install -y ./kube-bench_0.9.4_linux_amd64.deb ./linux-bench_0.5.0_linux_amd64.deb && \
-    rm *.deb
-
-# Copy and set entrypoint script
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
@@ -1,0 +1,25 @@
+# kubernetes/dockerfiles/cis-linux-and-kube-bench/Dockerfile
+FROM debian:bookworm-slim
+
+# Install base dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create reports directory
+RUN mkdir -p /reports
+
+# Download and install the benchmark tools
+# Download and install the benchmark tools
+RUN wget https://github.com/aquasecurity/kube-bench/releases/download/v0.9.4/kube-bench_0.9.4_linux_amd64.deb && \
+    wget https://github.com/aquasecurity/linux-bench/releases/download/v0.5.0/linux-bench_0.5.0_linux_amd64.deb && \
+    apt install -y ./kube-bench_0.9.4_linux_amd64.deb ./linux-bench_0.5.0_linux_amd64.deb && \
+    rm *.deb
+
+# Copy and set entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/bootstrap.sh
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/bootstrap.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Create directories
+mkdir -p /reports
+mkdir -p ./cfg/2.0.0
+mkdir -p ./cfg-kube/cis-1.24
+
+# Download linux-bench definitions.yaml
+wget -O ./cfg/2.0.0/definitions.yaml https://raw.githubusercontent.com/aquasecurity/linux-bench/main/cfg/2.0.0/definitions.yaml
+
+# Download kube-bench configs
+wget -O ./cfg-kube/config.yaml https://raw.githubusercontent.com/aquasecurity/kube-bench/main/cfg/config.yaml
+for file in config.yaml controlplane.yaml etcd.yaml master.yaml node.yaml policies.yaml; do
+    wget -O ./cfg-kube/cis-1.24/${file} https://raw.githubusercontent.com/aquasecurity/kube-bench/main/cfg/cis-1.24/${file}
+done
+
+# Download benchmark tools
+wget https://github.com/aquasecurity/kube-bench/releases/download/v0.9.4/kube-bench_0.9.4_linux_amd64.deb
+wget https://github.com/aquasecurity/linux-bench/releases/download/v0.5.0/linux-bench_0.5.0_linux_amd64.deb
+
+# Install benchmark tools
+apt install -y ./kube-bench_0.9.4_linux_amd64.deb ./linux-bench_0.5.0_linux_amd64.deb
+
+# Clean up
+rm *.deb

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/entrypoint.sh
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+TIMESTAMP=$(date +%Y-%m-%d-%H-%M-%S)
+CIS_LINUX_REPORT="/reports/${TIMESTAMP}-CIS-Linux-report.log"
+CIS_KUBE_REPORT="/reports/${TIMESTAMP}-CIS-kube-bench-report.log"
+
+# Run linux-bench checks
+echo "Starting CIS Linux Benchmark Check..."
+linux-bench \
+    --json \
+    --outputfile "$CIS_LINUX_REPORT" \
+    --include-test-output \
+    --logtostderr
+
+echo "Linux CIS Report generated at: $CIS_LINUX_REPORT"
+
+# Run kube-bench checks
+echo "Starting CIS Kubernetes Benchmark Check..."
+kube-bench run \
+    --json \
+    --outputfile "$CIS_KUBE_REPORT" \
+    --include-test-output \
+    --logtostderr
+
+echo "Kubernetes CIS Report generated at: $CIS_KUBE_REPORT"

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/entrypoint.sh
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/entrypoint.sh
@@ -22,6 +22,8 @@ kube-bench run \
     --json \
     --outputfile "$CIS_KUBE_REPORT" \
     --include-test-output \
-    --logtostderr
+    --logtostderr \
+    --config-dir ./cfg-kube/ \
+    --benchmark cis-1.24
 
 echo "Kubernetes CIS Report generated at: $CIS_KUBE_REPORT"

--- a/kubernetes/dockerfiles/cis-linux-and-kube-bench/entrypoint.sh
+++ b/kubernetes/dockerfiles/cis-linux-and-kube-bench/entrypoint.sh
@@ -11,7 +11,8 @@ linux-bench \
     --json \
     --outputfile "$CIS_LINUX_REPORT" \
     --include-test-output \
-    --logtostderr
+    --logtostderr \
+    --config-dir ./cfg/
 
 echo "Linux CIS Report generated at: $CIS_LINUX_REPORT"
 


### PR DESCRIPTION
The 'version_mapping' section was missing from the kube-bench config, causing a failure in the entrypoint script. This adds the required section to resolve the issue.
closes #7