### PR TITLE
fix(ansible): k8s-syncs-dels-namespaces

### DIFF
--- a/infrastructure/hetzner/k8s-resources.yml
+++ b/infrastructure/hetzner/k8s-resources.yml
@@ -22,6 +22,11 @@
         chart: "oci://registry-1.docker.io/bitnamicharts/nginx"
         repository: ""
         values_file: "{{ helm_charts_path }}/black/values.yaml"
+      - name: "metrics-server"
+        namespace: "kube-system"
+        chart: "oci://registry.k8s.io/metrics-server/metrics-server"
+        repository: "https://kubernetes-sigs.github.io/metrics-server/"
+        values_file: "{{ helm_charts_path }}/metrics-server/values.yaml"
   
   pre_tasks:
     # Check Kubernetes initialization
@@ -195,17 +200,17 @@
       register: k8s_files
 
     # Tried with apply --force and doesn't work for pods, using replace,
-    # which will DELETE and RECREATE all resources:    
+    # which will DELETE and RECREATE all resources, and apply for NEW resources:    
     - name: Apply all Kubernetes manifests with replace
-      ansible.builtin.shell: 
+      ansible.builtin.shell:
         cmd: "kubectl replace --force -f {{ item.path }}"
       loop: "{{ k8s_files.files }}"
       delegate_to: localhost
       become: no
-      register: kubectl_apply_result
-      changed_when: "'configured' in kubectl_apply_result.stdout or 'created' in kubectl_apply_result.stdout"
-      ignore_errors: yes  # This will allow other files to be processed even if one fails
-        
+      register: kubectl_replace_result
+      changed_when: "'replaced' in kubectl_replace_result.stdout or 'created' in kubectl_replace_result.stdout"
+      ignore_errors: yes
+             
 
         
     # This two step allows trying graceful apply or forcing if it failed
@@ -233,6 +238,7 @@
 #        - { name: nginx, url: https://nginx.github.io/helm-charts }
 #      delegate_to: localhost
 #      become: no
+
 
     # This is not working fine to apply updates, only to create new deployment
     # So to update it requires to manually delete

--- a/kubernetes/base/helm/metrics-server/Chart.yaml
+++ b/kubernetes/base/helm/metrics-server/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: metrics-server
+description: Metrics Server Helm Chart
+type: application
+version: 0.1.0
+dependencies:
+  - name: metrics-server
+    version: 3.11.0
+    repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/kubernetes/base/helm/metrics-server/values.yaml
+++ b/kubernetes/base/helm/metrics-server/values.yaml
@@ -1,0 +1,20 @@
+metrics-server:
+  args:
+    - --kubelet-insecure-tls
+    - --kubelet-preferred-address-types=InternalIP
+
+  hostNetwork:
+    enabled: true
+
+  metrics:
+    enabled: true
+
+  serviceMonitor:
+    enabled: false  # Enable if using Prometheus later
+
+  resources:
+    limits:
+      memory: 300Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi

--- a/kubernetes/base/manifests/namespace_black.yaml
+++ b/kubernetes/base/manifests/namespace_black.yaml
@@ -1,0 +1,8 @@
+# Requires separate yaml file for ansible kubecl replace, it uses a 
+# validating admission controller to prevent namespace recreate
+# from deleting all resources. This is a workaround due to ansible 
+# limitation to handle k8s syncs
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: black

--- a/kubernetes/base/manifests/namespace_seccomp.yaml
+++ b/kubernetes/base/manifests/namespace_seccomp.yaml
@@ -1,0 +1,8 @@
+# Requires separate yaml file for ansible kubecl replace, it uses a 
+# validating admission controller to prevent namespace recreate
+# from deleting all resources. This is a workaround due to ansible 
+# limitation to handle k8s syncs
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: seccomp-demo

--- a/kubernetes/base/manifests/namespace_white.yaml
+++ b/kubernetes/base/manifests/namespace_white.yaml
@@ -1,0 +1,8 @@
+# Requires separate yaml file for ansible kubecl replace, it uses a 
+# validating admission controller to prevent namespace recreate
+# from deleting all resources. This is a workaround due to ansible 
+# limitation to handle k8s syncs
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: white

--- a/kubernetes/base/manifests/namespaces.yaml
+++ b/kubernetes/base/manifests/namespaces.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: white
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: black

--- a/kubernetes/base/manifests/policy.yaml
+++ b/kubernetes/base/manifests/policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: prevent-namespace-deletion
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["DELETE"]
+      resources: ["namespaces"]
+  validations:
+    - expression: "false"
+      message: "Namespace deletion is not allowed"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: prevent-namespace-deletion-binding
+spec:
+  policyName: prevent-namespace-deletion
+  validationActions: [Deny]
+  matchResources: {}

--- a/kubernetes/base/manifests/seccomp-demo.yaml
+++ b/kubernetes/base/manifests/seccomp-demo.yaml
@@ -1,10 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: seccomp-demo
-
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: syscall-test-script


### PR DESCRIPTION

- Ansible re-run not deploying white-tests k8s config map
- The issue was it was deleting them via kubectl replace
- Added admission controller to prevent ns deletion

closes #24