### PR TITLE
feat(demo): Configure secure access via nginx ingress

### DIFF
--- a/infrastructure/hetzner/k8s-demo-secure-ingress.yml
+++ b/infrastructure/hetzner/k8s-demo-secure-ingress.yml
@@ -1,0 +1,55 @@
+- hosts: all
+  become: yes
+  vars_files:
+    - secret_vars.yml
+  vars:
+    docker_images_path: "../../kubernetes/dockerfiles"
+    k8s_manifests_path: "../../kubernetes/base/manifests"
+    helm_charts_path: "../../kubernetes/base/helm" 
+    registry_name: "local-registry"
+    registry_port: "5000"
+    ansible_become_pass: "{{ ansible_become_pass }}"
+  
+  
+  tasks:
+    - name: Generate self-signed certificate
+      command: >
+        openssl req -x509 -nodes -days 365 -newkey rsa:2048
+        -keyout /tmp/tls.key
+        -out /tmp/tls.crt
+        -subj "/CN=example.com"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Read certificate files
+      slurp:
+        src: "{{ item }}"
+      register: cert_files
+      loop:
+        - /tmp/tls.crt
+        - /tmp/tls.key
+      delegate_to: localhost
+      run_once: true
+
+    - name: Update TLS secret with certificate data
+      kubernetes.core.k8s:
+        kubeconfig: ~/.kube/config
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: nginx-tls-secret
+            namespace: default
+          type: kubernetes.io/tls
+          data:
+            tls.crt: "{{ cert_files.results[0].content }}"
+            tls.key: "{{ cert_files.results[1].content }}"
+      delegate_to: localhost
+
+    - name: Add hosts entry
+      lineinfile:
+        path: /etc/hosts
+        line: "{{ ansible_host }} example.com"
+        state: present
+      delegate_to: localhost

--- a/infrastructure/hetzner/k8s-resources.yml
+++ b/infrastructure/hetzner/k8s-resources.yml
@@ -27,6 +27,12 @@
         chart: "metrics-server/metrics-server"
         repository: "metrics-server"
         values_file: "{{ helm_charts_path }}/metrics-server/values.yaml"
+      - name: "ingress-nginx"
+        namespace: "ingress-nginx"
+        chart: "ingress-nginx/ingress-nginx"
+        repository: "https://kubernetes.github.io/ingress-nginx"
+        create_namespace: true
+        values_file: "{{ helm_charts_path }}/ingress-nginx/values.yaml"
   
   pre_tasks:
     # Check Kubernetes initialization
@@ -199,25 +205,30 @@
         
         images=(
           "registry.k8s.io/metrics-server/metrics-server:v0.7.2"
+          "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0"
         )
         
         for image in "${images[@]}"; do
-          # Pull the image
-          ctr -n=k8s.io image pull "$image"
+          # Pull with platform spec
+          ctr -n=k8s.io image pull --platform linux/amd64 "$image"
           
-          # Save the image
-          filename="/tmp/k8s-images/$(echo "$image" | tr '/:' '_').tar"
+          # Tag with digest if webhook certgen
+          if [[ $image == *"webhook-certgen"* ]]; then
+            ctr -n=k8s.io images tag "$image" "$image@sha256:aaafd456bda110628b2d4ca6296f38731a3aaf0bf7581efae824a41c770a8fc4"
+          fi
+          
+          # Export
+          filename="/tmp/k8s-images/$(echo "$image" | tr '/:@' '_').tar"
           ctr -n=k8s.io image export "$filename" "$image"
         done
         
-        # List the saved images
         ls -l /tmp/k8s-images/
       args:
         executable: /bin/bash
       delegate_to: localhost
-      register: image_pull_result
+      register: image_pull_result 
       changed_when: false
-
+ 
     - name: Find downloaded image files
       find:
         paths: /tmp/k8s-images
@@ -311,6 +322,8 @@
       loop:
         - name: metrics-server
           url: "https://kubernetes-sigs.github.io/metrics-server/"
+        - name: ingress-nginx
+          url: "https://kubernetes.github.io/ingress-nginx"
       delegate_to: localhost
       become: no
 

--- a/kubernetes/base/helm/ingress-nginx/Chart.yaml
+++ b/kubernetes/base/helm/ingress-nginx/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: ingress-nginx
+description: Ingress controller deployment
+type: application
+version: 0.1.0
+dependencies:
+  - name: ingress-nginx
+    version: 4.9.1
+    repository: https://kubernetes.github.io/ingress-nginx

--- a/kubernetes/base/helm/ingress-nginx/values.yaml
+++ b/kubernetes/base/helm/ingress-nginx/values.yaml
@@ -1,0 +1,13 @@
+controller:
+  service:
+    type: NodePort
+    nodePorts:
+      http: 30080
+      https: 30443
+  admissionWebhooks:
+    enabled: true
+    patch:
+      image:
+        pullPolicy: Never  
+  config:
+    ssl-redirect: true

--- a/kubernetes/base/manifests/demo-secure-ingress.yaml
+++ b/kubernetes/base/manifests/demo-secure-ingress.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-tls-secret
+  namespace: default
+type: kubernetes.io/tls
+data:
+  # These will be populated by the ansible script
+  tls.crt: ""
+  tls.key: ""
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-test
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-test
+  template:
+    metadata:
+      labels:
+        app: nginx-test
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: webpage
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: webpage
+        configMap:
+          name: nginx-webpage
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-test-service
+  namespace: default
+spec:
+  type: ClusterIP  
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: nginx-test
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-test-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "false"  # Added to clarify TLS termination
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"  # Force HTTPS
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: nginx-tls-secret
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-test-service
+            port:
+              number: 80
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-webpage
+  namespace: default
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Secure Nginx Test</title>
+    </head>
+    <body>
+        <h1>Secure Nginx Test Page</h1>
+        <p>This page is served over HTTPS with a self-signed certificate.</p>
+    </body>
+    </html>


### PR DESCRIPTION


- Set up secure external access to nginx test pod with self-signed certificate using NodePort.
- Config seems done, there a blocker issue during testing, commiting changes so far

Pausing #27 to fix blocker: #28