### PR TITLE
feat(infra): gitops-argocd-multiregion

### DIFF
--- a/infrastructure/aws-eks/terraform/environments/staging/main.tf
+++ b/infrastructure/aws-eks/terraform/environments/staging/main.tf
@@ -80,13 +80,13 @@ provider "kubectl" {
 
 provider "kubectl" {
   alias                  = "secondary"
-  host                   = module.eks_primary.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks_primary.cluster_certificate_authority_data)
+  host                   = module.eks_secondary.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_secondary.cluster_certificate_authority_data)
   load_config_file       = false
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
-    args        = ["eks", "get-token", "--cluster-name", module.eks_primary.cluster_name]
+    args        = ["eks", "get-token", "--cluster-name", module.eks_secondary.cluster_name]
   }
 }
 

--- a/infrastructure/aws-eks/terraform/modules/gitops/main.tf
+++ b/infrastructure/aws-eks/terraform/modules/gitops/main.tf
@@ -73,13 +73,21 @@ resource "helm_release" "argocd" {
           secretKey = data.aws_secretsmanager_secret_version.argocd_secret.secret_string
         }
       }
+      configs = {
+        repositories = {
+          git-repo = {
+            url = var.git_repo_url
+            type = "git"
+          }
+        }
+      }
       server = {
         extraArgs = ["--insecure"]
         service = {
-          type = "ClusterIP"
+          type = "LoadBalancer"
         }
         ingress = {
-          enabled = false
+          enabled = true
         }
         resources = {
           limits = {
@@ -190,8 +198,11 @@ resource "kubectl_manifest" "applicationset" {
          repoURL = var.git_repo_url
          revision = var.git_revision
          directories = [{
-           path = "kubernetes-aws-eks"
-           recurse = true
+           path = "kubernetes-aws-eks/base/*"
+           exclude = true
+         }, {
+           path = "kubernetes-aws-eks/apps/*"
+           exclude = true
          }]
        }
      }]


### PR DESCRIPTION


1) fix for kubectl port-forward acccess 'broken pipe' errors:
- changed argocd from ClusterIP to LoaddBalancer to get a public access
2) fix for repo no appearing in argocd automatiiclaly:
- git repo config added in argocd helm release
3) fix for inconsistenty in argocd status between regions
- updated kubectl module in the root main.tf for secondary region

Related to #72