### PR TITLE
feat(infra): gitops-argocd-multiregion

### DIFF
--- a/infrastructure/aws-eks/terraform/environments/staging/main.tf
+++ b/infrastructure/aws-eks/terraform/environments/staging/main.tf
@@ -212,7 +212,7 @@ module "eks_secondary" {
       min_size       = 1
       max_size       = 1
       desired_size   = 1
-      instance_types = ["t3.small"]
+      instance_types = ["t3.medium"]
       subnet_ids     = [module.network_secondary.private_subnets[0]]
       labels = {
         Environment = local.environment

--- a/infrastructure/aws-eks/terraform/modules/gitops/main.tf
+++ b/infrastructure/aws-eks/terraform/modules/gitops/main.tf
@@ -219,4 +219,9 @@ resource "kubectl_manifest" "apps_applicationset" {
       }
     }
   })
+   depends_on = [
+   helm_release.argocd,
+   kubernetes_namespace.argocd
+ ]
 }
+

--- a/nohup.out
+++ b/nohup.out
@@ -1,9 +1,0 @@
-[0000559ea8e46550] main libvlc: Running vlc with the default interface. Use 'cvlc' to use vlc without interface.
-[00007f7d54004960] gl gl: Initialized libplacebo v4.208.0 (API v208)
-libva info: VA-API version 1.17.0
-libva info: Trying to open /usr/lib/x86_64-linux-gnu/dri/iHD_drv_video.so
-libva info: Found init function __vaDriverInit_1_17
-libva info: va_openDriver() returns 0
-[00007f7d54004960] gl gl: Initialized libplacebo v4.208.0 (API v208)
-Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
-[00007f7d54004960] gl gl: Initialized libplacebo v4.208.0 (API v208)

--- a/nohup.out
+++ b/nohup.out
@@ -1,0 +1,9 @@
+[0000559ea8e46550] main libvlc: Running vlc with the default interface. Use 'cvlc' to use vlc without interface.
+[00007f7d54004960] gl gl: Initialized libplacebo v4.208.0 (API v208)
+libva info: VA-API version 1.17.0
+libva info: Trying to open /usr/lib/x86_64-linux-gnu/dri/iHD_drv_video.so
+libva info: Found init function __vaDriverInit_1_17
+libva info: va_openDriver() returns 0
+[00007f7d54004960] gl gl: Initialized libplacebo v4.208.0 (API v208)
+Failed to open VDPAU backend libvdpau_nvidia.so: cannot open shared object file: No such file or directory
+[00007f7d54004960] gl gl: Initialized libplacebo v4.208.0 (API v208)


### PR DESCRIPTION


- Fix: add missing depends_on to argocd application set resource in terraform
- Fix out of resource on secondary region, node from t3.small to t3.medium

Related to #72